### PR TITLE
Disable Jetifier to fix Android build failure

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 GOOGLE_MAPS_API_KEY=


### PR DESCRIPTION
## Summary
- Disable Android Jetifier in Gradle properties to avoid Byte Buddy transformation errors during GitHub Action builds

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a04d645b94832f8c408020b4e10427